### PR TITLE
multi stage dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,22 @@
-ARG ARCH="amd64"
-ARG OS="linux"
-FROM quay.io/prometheus/busybox-${OS}-${ARCH}:latest
+FROM --platform=$BUILDPLATFORM alpine:3.23 AS builder
 LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
-ARG ARCH="amd64"
-ARG OS="linux"
-COPY .build/${OS}-${ARCH}/mysqld_exporter /bin/mysqld_exporter
+WORKDIR /usr/src/mysqld_exporter
+COPY . .
 
-EXPOSE      9104
-USER        nobody
-ENTRYPOINT  [ "/bin/mysqld_exporter" ]
+RUN apk add --no-cache git make musl-dev go
+
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -v -o mysqld_exporter .
+
+FROM alpine:3.23 AS app
+
+COPY --from=builder /usr/src/mysqld_exporter/mysqld_exporter /bin/mysqld_exporter
+
+EXPOSE 9104
+
+USER nobody
+
+CMD [ "/bin/mysqld_exporter" ]


### PR DESCRIPTION
This is to fix the issue with the build workflow, as it appears it's failed as it's not built for both arm64 and amd64.

It creates a multi stage dockerfile which will build the image for both architectures above, allowing us to use our build file.

Thought - do we need the user "nobody"? As we put our cnf file into the root directory anyway? Beyond that, this built, and started locally - then exited as the config file wasn't present (which is expected).

Resolves BAB-594